### PR TITLE
開発環境のみ、欲しいファイルを除外しました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.dockerignore
+.python-version
+.venv
+.env


### PR DESCRIPTION
開発環境ではほしいけど、リモートには不要なファイルを除外しました。

`.dockerignore` Dockerでビルドする時に、含めたくないフォルダーを除外
`.python-version` pyenv使用時にpythonのバージョンを指定する際に必要
`.venv` venv使用時に作成されるフォルダー
`.env` トークン等を入れる。ここに書いたやつを環境変数として呼び出せる

pyenvとvenvはpythonの仮想環境 
他プロジェクトとインストール済みライブラリを分けたいので