### PR TITLE
シークレットトークンを参照してDiscordBOTを起動させる様に変更しました。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ ENV LANGUAGE ja_JP:ja
 ENV LC_ALL ja_JP.UTF-8
 ENV TZ JST-9
 ENV TERM xterm
-ENV DISCORD_TOKEN DISCORD_TOKEN_SECRET
 
 RUN apt-get install -y vim less
 


### PR DESCRIPTION
# トークンの設定方法
1. GCPにおいて、セキュリティ→Secret Managerを選択
2. 表示されたリスト内から、**discord-token**を選択
3. **+新しいバージョン**を選択
4. **シークレットの値**にDiscordのtokenを追加する。
5. **新しいバージョンを追加する**を選択
6. 古いバージョンのシークレットの三点リーダを選択し、**無効にする**を選択
# トークンをデプロイ環境に含ませる
1. Cloud Runの**新しいリビジョンの編集とデプロイ**を選択
2. 一番下にあるシークレットに**discord-token**の欄があるので、それを開く
3. 環境変数のバージョンを最新に更新する。(latestにする)