### PR TITLE
リアクション認証システムの追加

### DIFF
--- a/app/demo.py
+++ b/app/demo.py
@@ -12,6 +12,7 @@ def index():
 def run():
     app.run(host="0.0.0.0", port=8080)
 
+
 def keep_alive():
     thread = Thread(target=run)
     thread.start()

--- a/app/main.py
+++ b/app/main.py
@@ -6,8 +6,8 @@ intents = discord.Intents.default()
 intents.message_content = True
 client = discord.Client(intents=intents)
 
-#AUTH_MESSAGE_ID = 744216836173725846
-AUTH_MESSAGE_ID = 1054854789877465158
+AUTH_MESSAGE_ID = 744216836173725846
+#AUTH_MESSAGE_ID = 1054854789877465158
 
 
 REACTION_TO_ROLE = {

--- a/app/main.py
+++ b/app/main.py
@@ -2,19 +2,6 @@ import os
 import discord
 from demo import keep_alive
 
-intents = discord.Intents.default()
-intents.message_content = True
-client = discord.Client(intents=intents)
-
-AUTH_MESSAGE_ID = 744216836173725846
-
-REACTION_TO_ROLE = {
-    744209790837850122: 587175233899724801, # デザイナー
-    744209790661820438: 587175050571022337, # プログラマー
-    832489218546335764: 832617526005071923, # サウンド
-    797122177794441248: 797121076827258890 # VTUBER
-}
-
 
 def exit(msg: str) -> None:
     """
@@ -32,10 +19,24 @@ def exit(msg: str) -> None:
     """
     print(msg)
     import sys
+
     sys.exit()
 
 
-TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Client(intents=intents)
+
+AUTH_MESSAGE_ID = 744216836173725846
+
+REACTION_TO_ROLE = {
+    744209790837850122: 587175233899724801,  # デザイナー
+    744209790661820438: 587175050571022337,  # プログラマー
+    832489218546335764: 832617526005071923,  # サウンド
+    797122177794441248: 797121076827258890,  # VTUBER
+}
+
+TOKEN = os.getenv("DISCORD_TOKEN_SECRET")
 
 # システム環境変数にTOKENが見つからなかった時に.envから読み取るようにする
 # .envに記載が無い時も処理を中断
@@ -49,7 +50,7 @@ if not TOKEN:
     from dotenv import load_dotenv
 
     load_dotenv()
-    TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
+    TOKEN = os.getenv("DISCORD_TOKEN_SECRET")
     print(".envからTOKENを取得しました。")
 
     if not TOKEN:
@@ -58,32 +59,36 @@ if not TOKEN:
 
 @client.event
 async def on_ready():
-    print(f'We have logged in as {client.user}')
+    print(f"We have logged in as {client.user}")
+
 
 @client.event
 async def on_message(message: discord.Message):
     if message.author == client.user:
         return
     await message.channel.send(message.content)
-    if message.content.startswith('$hello'):
-        await message.channel.send('Hello!')
+    if message.content.startswith("$hello"):
+        await message.channel.send("Hello!")
 
 
 @client.event
 async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     # リアクションを付けたメッセージのIDが指定したものじゃなければ処理を中断
-    if payload.message_id != AUTH_MESSAGE_ID: return
+    if payload.message_id != AUTH_MESSAGE_ID:
+        return
 
     # GUILDオブジェクトを取得
     guild = client.get_guild(payload.guild_id)
 
     # カスタム絵文字じゃ無かったらそれ以降処理しない
-    if not payload.emoji.is_custom_emoji(): return
+    if not payload.emoji.is_custom_emoji():
+        return
 
     # 押されたリアクションのIDが辞書のキーにあるか調べる
     # もしあれば、対応したロールIDを取得する
-    if not (role_id := REACTION_TO_ROLE.get(payload.emoji.id)): return
-    
+    if not (role_id := REACTION_TO_ROLE.get(payload.emoji.id)):
+        return
+
     # 取得したロールIDからロールオブジェクトを取得
     role = guild.get_role(role_id)
 
@@ -98,8 +103,6 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
 
     # 取得したロールをリアクションを押したメンバーに付与する
     await member.add_roles(role)
-
-
 
 
 keep_alive()

--- a/app/main.py
+++ b/app/main.py
@@ -61,7 +61,7 @@ async def on_ready():
     print(f'We have logged in as {client.user}')
 
 @client.event
-async def on_message(message):
+async def on_message(message: discord.Message):
     if message.author == client.user:
         return
     await message.channel.send(message.content)

--- a/app/main.py
+++ b/app/main.py
@@ -7,14 +7,12 @@ intents.message_content = True
 client = discord.Client(intents=intents)
 
 AUTH_MESSAGE_ID = 744216836173725846
-#AUTH_MESSAGE_ID = 1054854789877465158
-
 
 REACTION_TO_ROLE = {
-    744209790837850122: 587175233899724801, #デザイナー
-    744209790661820438: 587175050571022337, #プログラマー
-    832489218546335764: 832617526005071923, #サウンド
-    797122177794441248: 797121076827258890 #VTUBER
+    744209790837850122: 587175233899724801, # デザイナー
+    744209790661820438: 587175050571022337, # プログラマー
+    832489218546335764: 832617526005071923, # サウンド
+    797122177794441248: 797121076827258890 # VTUBER
 }
 
 
@@ -37,23 +35,18 @@ def exit(msg: str) -> None:
     sys.exit()
 
 
-# 後でtokenをどうにかする
 TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
 
-#システム環境変数にTOKENが見つからなかった時に.envから読み取るようにする
-#requirements.txtに記載したpython-dotenvがインポートできなかった時に起動を中断
-#.envに記載が無い時も処理を中断
-#.envにXX="YY"と記載したとき、XXが変数名になる
-#TOKEN = os.getenv('XX')と記載したらYYを取得できる
+# システム環境変数にTOKENが見つからなかった時に.envから読み取るようにする
+# .envに記載が無い時も処理を中断
+# .envにXX="YY"と記載したとき、XXが変数名になる
+# TOKEN = os.getenv('XX')と記載したらYYを取得できる
 
-#XX is Noneとnot XXは同じ
+# XX is Noneとnot XXは同じ
 
 
 if not TOKEN:
-    try:
-        from dotenv import load_dotenv
-    except ImportError:
-        exit("TOKENが見つからなかったため、処理を中断しました。")
+    from dotenv import load_dotenv
 
     load_dotenv()
     TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
@@ -78,32 +71,32 @@ async def on_message(message):
 
 @client.event
 async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
-    #リアクションを付けたメッセージのIDが指定したものじゃなければ処理を中断
+    # リアクションを付けたメッセージのIDが指定したものじゃなければ処理を中断
     if payload.message_id != AUTH_MESSAGE_ID: return
 
-    #GUILDオブジェクトを取得
+    # GUILDオブジェクトを取得
     guild = client.get_guild(payload.guild_id)
 
-    #カスタム絵文字じゃ無かったらそれ以降処理しない
+    # カスタム絵文字じゃ無かったらそれ以降処理しない
     if not payload.emoji.is_custom_emoji(): return
 
-    #押されたリアクションのIDが辞書のキーにあるか調べる
-    #もしあれば、対応したロールIDを取得する
+    # 押されたリアクションのIDが辞書のキーにあるか調べる
+    # もしあれば、対応したロールIDを取得する
     if not (role_id := REACTION_TO_ROLE.get(payload.emoji.id)): return
     
-    #取得したロールIDからロールオブジェクトを取得
+    # 取得したロールIDからロールオブジェクトを取得
     role = guild.get_role(role_id)
 
     if not role:
         print(f"{role_id} がサーバーに見つかりませんでした。")
         return
 
-    #たまーにpayload.memberがNoneになることがある
-    #Noneになったらリアクションを押したユーザーのIDを元にサーバーに入ってるメンバー一覧から押したユーザーを取得する
+    # たまーにpayload.memberがNoneになることがある
+    # Noneになったらリアクションを押したユーザーのIDを元にサーバーに入ってるメンバー一覧から押したユーザーを取得する
     if not (member := payload.member):
         member = guild.get_member(payload.user_id)
 
-    #取得したロールをリアクションを押したメンバーに付与する
+    # 取得したロールをリアクションを押したメンバーに付与する
     await member.add_roles(role)
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,38 @@ client = discord.Client(intents=intents)
 # 後でtokenをどうにかする
 TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
 
+def exit(msg: str) -> None:
+    """
+    処理を中断する時に実行される関数
+
+    Parameters
+    ----------
+    msg: str
+        終了する時に出力するメッセージ
+
+    Returns
+    -------
+    None
+
+    """
+    print(msg)
+    import sys
+    sys.exit()
+
+
+if TOKEN is None:
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        exit("TOKENが見つからなかったため、処理を中断しました。")
+
+    load_dotenv()
+    TOKEN = os.getenv('DISCORD_TOKEN_SECRET')
+
+    if TOKEN is None:
+        exit("TOKENが見つからなかったため、処理を中断しました。")
+
+
 @client.event
 async def on_ready():
     print(f'We have logged in as {client.user}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ setuptools
 numpy
 discord.py[voice]
 flask
+python-dotenv


### PR DESCRIPTION
現行しているちびてらBOTのリアクション認証システムの簡易版を移行しました。

ローカル環境では`app/.env`にトークンを記載しそこから呼び出すようにしたいので、そう出来るようにトークンの読み込み部分を追記しました。

メッセージIDとリアクションID・ロールIDを直書きしてますが、
外部からサーバー内の情報を取得するにはサーバーID or チャンネルIDのどちらかが必要になるので問題無いと判断しました。

処理内容についてはコメントに記載してる通りです